### PR TITLE
remove postgresql zone

### DIFF
--- a/modules/web_app/database.tf
+++ b/modules/web_app/database.tf
@@ -13,7 +13,6 @@ resource "azurerm_postgresql_flexible_server" "db_server" {
   administrator_login    = local.db_config.admin_db_user
   administrator_password = local.db_config.admin_db_password
   version                = local.db_config.version
-  zone                   = local.db_config.zone
 
   lifecycle {
     prevent_destroy = true

--- a/modules/web_app/locals.tf
+++ b/modules/web_app/locals.tf
@@ -35,6 +35,5 @@ locals {
     backup_retention_days         = 7
     geo_redundant_backup_enabled  = false
     public_network_access_enabled = true
-    zone                          = "2"
   }
 }


### PR DESCRIPTION
This PR removes the optional `azurerm_postgresql_flexible_server` availability zone argument, as some Azure accounts seem to not have availability zones enabled this service.

![Screenshot 2023-05-31 at 14 14 41](https://github.com/code4romania/terraform-azure-paul/assets/1569300/3c4494e6-b7a3-4bd0-89ff-d195b9ab8565)

It's not currently clear why this is happening.